### PR TITLE
Adding top-module to apio.ini for newer apio versions

### DIFF
--- a/contador/apio.ini
+++ b/contador/apio.ini
@@ -1,3 +1,3 @@
 [env]
 board = edu-ciaa-fpga
-
+top-module = contador

--- a/contador/contador_01/apio.ini
+++ b/contador/contador_01/apio.ini
@@ -1,3 +1,4 @@
 [env]
 board = edu-ciaa-fpga
+top-module = contador_01
 

--- a/contador/contador_02/apio.ini
+++ b/contador/contador_02/apio.ini
@@ -1,3 +1,4 @@
 [env]
 board = edu-ciaa-fpga
+top-module = contador_02
 

--- a/contador/contador_ud_p/apio.ini
+++ b/contador/contador_ud_p/apio.ini
@@ -1,3 +1,4 @@
 [env]
 board = edu-ciaa-fpga
+top-module = contador_ud_p
 


### PR DESCRIPTION
Hola profe le comento que tuve una advertencia desde el comando `apio verify` en los distintos ejemplos luego de clonar el repositorio dado que estos no tenian el `top-module` asignado.